### PR TITLE
Added inline to bit_value::swap to resolve link error.

### DIFF
--- a/cpp/bit_value.hpp
+++ b/cpp/bit_value.hpp
@@ -265,7 +265,7 @@ constexpr bit_value::operator bool(
 
 // ------------------------ BIT VALUE: SWAP MEMBERS ------------------------- //
 // Swaps the bit value with another bit value
-void bit_value::swap(
+inline void bit_value::swap(
     bit_value& other
 ) noexcept
 {


### PR DESCRIPTION
The class *bit_value* has member functions whose definition is stated in the header file.  I got a link error when including bit.hpp from two different files. There are other member functions should be inlined. This is not an issue for templated member function defined in the header file.